### PR TITLE
Make AccumulatorBase destructor virtual

### DIFF
--- a/include/utils/AccumulatorBase.h
+++ b/include/utils/AccumulatorBase.h
@@ -23,7 +23,7 @@ class AccumulatorBase
 {
 public:
   AccumulatorBase(FEProblemBase & problem);
-  ~AccumulatorBase();
+  virtual ~AccumulatorBase();
 
   /**
    * Accumulates a value into the field


### PR DESCRIPTION
A base class public destructor should also be virtual. This fixes failing tests seen on my ARM Mac this morning. Adding valgrind testing here as well. 

Refs #17

CC: @loganharbour 