### PR TITLE
Updated build macros to match new naming schemes used in OpenMC.

### DIFF
--- a/config/build_deps.mk
+++ b/config/build_deps.mk
@@ -15,7 +15,10 @@ ifeq ($(ENABLE_CARDINAL),yes)
   libmesh_CXXFLAGS    += -DENABLE_OPENMC_COUPLING
 
   # Add DagMC flags (-DDAGMC is used in OpenMC)
-  libmesh_CXXFLAGS    += -DENABLE_DAGMC -DDAGMC
+  libmesh_CXXFLAGS    += -DOPENMC_DAGMC_ENABLED -DDAGMC 
+
+  # Add libmesh flags (-DOPENMC_LIBMESH_ENABLED is used in OpenMC)
+	libmesh_CXXFLAGS    += -DOPENMC_LIBMESH_ENABLED
 
   # Disable Double-Down (optional dependency of DagMC) by default for now
   # (see https://github.com/neams-th-coe/cardinal/pull/1142).

--- a/config/build_deps.mk
+++ b/config/build_deps.mk
@@ -15,7 +15,7 @@ ifeq ($(ENABLE_CARDINAL),yes)
   libmesh_CXXFLAGS    += -DENABLE_OPENMC_COUPLING
 
   # Add DagMC flags (-DDAGMC is used in OpenMC)
-  libmesh_CXXFLAGS    += -DDAGMC_ENABLED -DOPENMC_DAGMC_ENABLED
+  libmesh_CXXFLAGS    += -DENABLE_DAGMC -DOPENMC_DAGMC_ENABLED
 
   # Add libmesh flags (-DOPENMC_LIBMESH_ENABLED is used in OpenMC)
 	libmesh_CXXFLAGS    += -DOPENMC_LIBMESH_ENABLED

--- a/config/build_deps.mk
+++ b/config/build_deps.mk
@@ -15,7 +15,7 @@ ifeq ($(ENABLE_CARDINAL),yes)
   libmesh_CXXFLAGS    += -DENABLE_OPENMC_COUPLING
 
   # Add DagMC flags (-DDAGMC is used in OpenMC)
-  libmesh_CXXFLAGS    += -DOPENMC_DAGMC_ENABLED -DDAGMC 
+  libmesh_CXXFLAGS    += -DDAGMC_ENABLED -DOPENMC_DAGMC_ENABLED
 
   # Add libmesh flags (-DOPENMC_LIBMESH_ENABLED is used in OpenMC)
 	libmesh_CXXFLAGS    += -DOPENMC_LIBMESH_ENABLED


### PR DESCRIPTION
Updated some of the OpenMC macro defs in build_deps.mk to match the new macro names used in OpenMC. The currently pinned Cardinal commit is completely unproblematic in this regard, so this may be a PR for the future:)