### PR TITLE
Moving `TestSimpleStepper` to `SimpleStepper`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -328,3 +328,6 @@ salamander-unit.yaml
 
 # Cardinal
 cross_sections
+
+# Salamander
+doc/content/verification_validation_examples/plasma/figures/*.png

--- a/doc/content/source/userobjects/SimpleStepper.md
+++ b/doc/content/source/userobjects/SimpleStepper.md
@@ -2,8 +2,8 @@
 
 !syntax description /UserObjects/SimpleStepper
 
-The SimpleStepper is intended to be used when simulating flow where the particles in the system are not subject to any external forces.
-This object sets the particles to trace along it's current direction with the maximum distance set by the current velocity and time step.
+The SimpleStepper is intended to be used when simulating flows where the particles in the system are not subject to any external forces. One example of this is neutral particle simulations.
+This object sets the particles to trace along its current direction with the maximum distance set by the current velocity and time step.
 
 # Example Input Syntax
 

--- a/doc/content/source/userobjects/SimpleStepper.md
+++ b/doc/content/source/userobjects/SimpleStepper.md
@@ -1,0 +1,17 @@
+# SimpleStepper
+
+!syntax description /UserObjects/SimpleStepper
+
+The SimpleStepper is intended to be used when simulating flow where the particles in the system are not subject to any external forces.
+This object sets the particles to trace along it's current direction with the maximum distance set by the current velocity and time step.
+
+# Example Input Syntax
+
+!listing test/tests/userobjects/particle_stepper/simple_stepping/simple_stepping.i block=UserObjects
+
+!syntax parameters /UserObjects/SimpleStepper
+
+!syntax inputs /UserObjects/SimpleStepper
+
+!syntax children /UserObjects/SimpleStepper
+

--- a/include/userobjects/SimpleStepper.h
+++ b/include/userobjects/SimpleStepper.h
@@ -1,5 +1,5 @@
 //* This file is part of SALAMANDER: Software for Advanced Large-scale Analysis of MAgnetic
-//confinement for Numerical Design, Engineering & Research,
+// confinement for Numerical Design, Engineering & Research,
 //* A multiphysics application for modeling plasma facing components
 //* https://github.com/idaholab/salamander
 //* https://mooseframework.inl.gov/salamander

--- a/include/userobjects/SimpleStepper.h
+++ b/include/userobjects/SimpleStepper.h
@@ -1,4 +1,5 @@
-//* This file is part of SALAMANDER: Software for Advanced Large-scale Analysis of MAgnetic confinement for Numerical Design, Engineering & Research,
+//* This file is part of SALAMANDER: Software for Advanced Large-scale Analysis of MAgnetic
+//confinement for Numerical Design, Engineering & Research,
 //* A multiphysics application for modeling plasma facing components
 //* https://github.com/idaholab/salamander
 //* https://mooseframework.inl.gov/salamander
@@ -17,10 +18,10 @@
 
 #include "ParticleStepperBase.h"
 
-class TestSimpleStepper : public ParticleStepperBase
+class SimpleStepper : public ParticleStepperBase
 {
 public:
-  TestSimpleStepper(const InputParameters & parameters);
+  SimpleStepper(const InputParameters & parameters);
 
   static InputParameters validParams();
 

--- a/src/userobjects/SimpleStepper.C
+++ b/src/userobjects/SimpleStepper.C
@@ -22,8 +22,9 @@ InputParameters
 SimpleStepper::validParams()
 {
   auto params = ParticleStepperBase::validParams();
-  params.addClassDescription("Simple test stepper which does not modify the particle velocity just "
-                             "updates the direction and maximum distance");
+  params.addClassDescription(
+      "This stepper does not modify the particle velocity just "
+      "updates the direction and maximum distance based on the currently velocity and timestep.");
   return params;
 }
 

--- a/src/userobjects/SimpleStepper.C
+++ b/src/userobjects/SimpleStepper.C
@@ -1,4 +1,5 @@
-//* This file is part of SALAMANDER: Software for Advanced Large-scale Analysis of MAgnetic confinement for Numerical Design, Engineering & Research,
+//* This file is part of SALAMANDER: Software for Advanced Large-scale Analysis of MAgnetic
+// confinement for Numerical Design, Engineering & Research,
 //* A multiphysics application for modeling plasma facing components
 //* https://github.com/idaholab/salamander
 //* https://mooseframework.inl.gov/salamander
@@ -13,12 +14,12 @@
 //* ALL RIGHTS RESERVED
 //*
 
-#include "TestSimpleStepper.h"
+#include "SimpleStepper.h"
 
-registerMooseObject("SalamanderTestApp", TestSimpleStepper);
+registerMooseObject("SalamanderApp", SimpleStepper);
 
 InputParameters
-TestSimpleStepper::validParams()
+SimpleStepper::validParams()
 {
   auto params = ParticleStepperBase::validParams();
   params.addClassDescription("Simple test stepper which does not modify the particle velocity just "
@@ -26,16 +27,15 @@ TestSimpleStepper::validParams()
   return params;
 }
 
-TestSimpleStepper::TestSimpleStepper(const InputParameters & parameters)
-  : ParticleStepperBase(parameters)
+SimpleStepper::SimpleStepper(const InputParameters & parameters) : ParticleStepperBase(parameters)
 {
 }
 
 void
-TestSimpleStepper::setupStep(Ray & ray,
-                             Point & v,
-                             const Real /*q_m_ratio*/,
-                             const Real /*disatnce*/) const
+SimpleStepper::setupStep(Ray & ray,
+                         Point & v,
+                         const Real /*q_m_ratio*/,
+                         const Real /*disatnce*/) const
 {
   setMaxDistanceAndDirection(ray, v, _dt);
 }

--- a/src/userobjects/SimpleStepper.C
+++ b/src/userobjects/SimpleStepper.C
@@ -23,8 +23,8 @@ SimpleStepper::validParams()
 {
   auto params = ParticleStepperBase::validParams();
   params.addClassDescription(
-      "This stepper does not modify the particle velocity just "
-      "updates the direction and maximum distance based on the currently velocity and timestep.");
+      "This stepper does not modify the particle velocity; it simply "
+      "updates the direction and maximum distance based on the current velocity and timestep.");
   return params;
 }
 
@@ -36,7 +36,7 @@ void
 SimpleStepper::setupStep(Ray & ray,
                          Point & v,
                          const Real /*q_m_ratio*/,
-                         const Real /*disatnce*/) const
+                         const Real /*distance*/) const
 {
   setMaxDistanceAndDirection(ray, v, _dt);
 }

--- a/test/tests/raybcs/reflection_base.i
+++ b/test/tests/raybcs/reflection_base.i
@@ -4,7 +4,7 @@
 
 [UserObjects]
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [velocity_initializer]

--- a/test/tests/userobjects/particle_initializer/bounding_box/elements/initializer_base.i
+++ b/test/tests/userobjects/particle_initializer/bounding_box/elements/initializer_base.i
@@ -23,7 +23,7 @@ charge_density = 2
 
 [UserObjects]
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [velocity_initializer]

--- a/test/tests/userobjects/particle_initializer/bounding_box/errors/errors.i
+++ b/test/tests/userobjects/particle_initializer/bounding_box/errors/errors.i
@@ -37,7 +37,7 @@ charge_density = 2
   []
 
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [study]

--- a/test/tests/userobjects/particle_initializer/per_element/elements/initializer_base.i
+++ b/test/tests/userobjects/particle_initializer/per_element/elements/initializer_base.i
@@ -63,7 +63,7 @@ charge_density = 0
   []
 
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [study]

--- a/test/tests/userobjects/particle_initializer/per_element/errors/errors.i
+++ b/test/tests/userobjects/particle_initializer/per_element/errors/errors.i
@@ -28,7 +28,7 @@
   []
 
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [study]

--- a/test/tests/userobjects/particle_initializer/uniform_grid/uniform_grid.i
+++ b/test/tests/userobjects/particle_initializer/uniform_grid/uniform_grid.i
@@ -18,7 +18,7 @@
     velocities = '0 0 0'
   []
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [particle_initializer]

--- a/test/tests/userobjects/particle_quantity_accumulation/number_density_accumulator.i
+++ b/test/tests/userobjects/particle_quantity_accumulation/number_density_accumulator.i
@@ -29,7 +29,7 @@
 
 [UserObjects]
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [velocity_initializer]

--- a/test/tests/userobjects/particle_quantity_accumulation/simple_potential_solve.i
+++ b/test/tests/userobjects/particle_quantity_accumulation/simple_potential_solve.i
@@ -42,7 +42,7 @@
 
 [UserObjects]
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [velocity_initializer]

--- a/test/tests/userobjects/particle_stepper/simple_stepping/simple_stepping.i
+++ b/test/tests/userobjects/particle_stepper/simple_stepping/simple_stepping.i
@@ -11,7 +11,7 @@
 
 [UserObjects]
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [velocity_initializer]

--- a/test/tests/userobjects/particle_stepper/simple_stepping/tests
+++ b/test/tests/userobjects/particle_stepper/simple_stepping/tests
@@ -1,5 +1,5 @@
 [Tests]
-  design = 'ParticleStepperBase.md PICStudyBase.md'
+  design = 'SimpleStepper.md ParticleStepperBase.md PICStudyBase.md'
   issues = '#4'
   [simple_stepping]
     type = 'CSVDiff'

--- a/test/tests/utils/auxaccumulator/charge_accumulator_base.i
+++ b/test/tests/utils/auxaccumulator/charge_accumulator_base.i
@@ -9,7 +9,7 @@
 
 [UserObjects]
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [velocity_initializer]

--- a/test/tests/utils/auxaccumulator/simple_potential_solve_aux.i
+++ b/test/tests/utils/auxaccumulator/simple_potential_solve_aux.i
@@ -45,7 +45,7 @@
   []
 
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [particle_initializer]

--- a/test/tests/utils/variable_sampler/variable_sampler.i
+++ b/test/tests/utils/variable_sampler/variable_sampler.i
@@ -31,7 +31,7 @@
 
 [UserObjects]
   [stepper]
-    type = TestSimpleStepper
+    type = SimpleStepper
   []
 
   [velocity_initializer]


### PR DESCRIPTION
Closes #149 to help facilitate neutral flow simulations more obviously. 

Also updated the .gitignore so that the temporary image files generated when building the docs are not tracked. 