### PR TITLE
Appropriately typing _mesh_dimension.

### DIFF
--- a/include/userobjects/ParticleInitializerBase.h
+++ b/include/userobjects/ParticleInitializerBase.h
@@ -70,7 +70,7 @@ protected:
   /// a user specified seed for changing random number generator seeds
   const unsigned int _seed;
   /// the dimension of the finite element mesh
-  const Real _mesh_dimension;
+  const unsigned int _mesh_dimension;
   /// The velocity initializer which will give all particles their initial velocity distribution
   const VelocityInitializerBase & _velocity_initializer;
 };

--- a/include/userobjects/ParticleStepperBase.h
+++ b/include/userobjects/ParticleStepperBase.h
@@ -80,5 +80,5 @@ protected:
    */
   Point linearImpulse(const Point & v, const Point & F, const Real q_m_ratio, const Real dt) const;
   /// the dimension of the mesh being using used for dimension-dependent velocity updates
-  const Real _mesh_dimension;
+  const unsigned int _mesh_dimension;
 };


### PR DESCRIPTION
- Changed mesh dimension storage from a Real to an unsigned int it should not cause any differences since Reals should be able to represent integer values 0-2 exactly but it is still the wrong type

Closes #153 